### PR TITLE
opr: Fully initialize sockaddr_in

### DIFF
--- a/src/opr/sockaddr.c
+++ b/src/opr/sockaddr.c
@@ -27,6 +27,11 @@
 #include <roken.h>
 #include "sockaddr.h"
 
+#ifdef KERNEL
+# include "afs/sysincludes.h"
+# include "afsincludes.h"
+#endif
+
 /*
  * Supports only AF_INET (IPv4) at this time.
  */

--- a/src/opr/sockaddr.c
+++ b/src/opr/sockaddr.c
@@ -58,6 +58,10 @@ opr_sockaddr_by_inet(opr_sockaddr *dst, struct in_addr addr, afs_uint16 port)
     dst->u.in.sin_family = AF_INET;
     dst->u.in.sin_addr.s_addr = addr.s_addr;
     dst->u.in.sin_port = port;
+    memset(&dst->u.in.sin_zero, 0, sizeof(dst->u.sin_zero));
+#ifdef STRUCT_SOCKADDR_AHS_SA_LEN
+    dst->u.in.sin_len = sizeof(struct sockaddr_in);
+#endif
     return 0;
 }
 
@@ -86,5 +90,9 @@ opr_sockaddr_copy(opr_sockaddr *dst, opr_sockaddr *src)
     dst->u.in.sin_family = AF_INET;
     dst->u.in.sin_addr.s_addr = src->u.in.sin_addr.s_addr;
     dst->u.in.sin_port = src->u.in.sin_port;
+    memset(&dst->u.in.sin_zero, 0, sizeof(dst->u.sin_zero));
+#ifdef STRUCT_SOCKADDR_AHS_SA_LEN
+    dst->u.in.sin_len = sizeof(struct sockaddr_in);
+#endif
     return 0;
 }


### PR DESCRIPTION
Initialize sin_len and sin_zero when setting or copying a opr_sockaddr.

Change-Id: I9d0c3385bdd55a6576c0fcc0be731eed9492c0dc